### PR TITLE
os_images changes

### DIFF
--- a/roles/os_images/README.md
+++ b/roles/os_images/README.md
@@ -2,7 +2,7 @@ OpenStack Images
 ================
 
 This role generates guest instance images using disk-image-builder
-and uploads them to OpenStack using the `os_image` module.
+and uploads them to OpenStack using the `openstack.cloud.image` module.
 
 Requirements
 ------------
@@ -126,9 +126,9 @@ The following playbook generates a guest image and uploads it to OpenStack:
 
     ---
     - name: Generate guest image and upload
-      hosts: openstack
+      hosts: localhost
       roles:
-        - role: stackhpc.os-images
+        - role: stackhpc.openstack.os_images
           os_images_auth:
             auth_url:     "{{ lookup('env','OS_AUTH_URL') }}"
             username:     "{{ lookup('env','OS_USERNAME') }}"

--- a/roles/os_images/README.md
+++ b/roles/os_images/README.md
@@ -102,7 +102,7 @@ will be replaced with the newly built image if `os_images_upload` is set to `Tru
 
 `os_images_public`: (Deprecated - use `os_images_visibility`) Whether uploaded images are public. Defaults to `True` - note this requires admin permissions. 
 
-`os_images_visibility`: The visibility of images uploaded. Defaults to public/private, based off `os_images_public` - note this requires admin permissions.
+`os_images_visibility`: The visibility of images uploaded. One of `community`,`public` or `private. If unset, defaults to `os_images_public` (requires admin permissions for anything other than `private`)
 
 `os_images_venv`: Path to virtualenv in which to install python dependencies to upload images.
 

--- a/roles/os_images/README.md
+++ b/roles/os_images/README.md
@@ -108,7 +108,9 @@ will be replaced with the newly built image if `os_images_upload` is set to `Tru
 
 `os_images_dib_venv`: Path to virtualenv in which to install DIB to build images.
 
-`os_images_promote`: Whether or not to retire old and promote new images. Defaults to `False`.
+`os_images_promote`: Whether or not to promote new images. Defaults to `False`.
+
+`os_images_retire`: Whether or not to retire old images. Defaults to `os_image_promote`. May be necessary to set separately if you are promoting a new candidate image for which there is no existing one to retire, for example. 
 
 `os_images_build`: Whether or not to build the images.
 

--- a/roles/os_images/README.md
+++ b/roles/os_images/README.md
@@ -102,7 +102,7 @@ will be replaced with the newly built image if `os_images_upload` is set to `Tru
 
 `os_images_public`: (Deprecated - use `os_images_visibility`) Whether uploaded images are public. Defaults to `True` - note this requires admin permissions. 
 
-`os_images_visibility`: The visibility of images uploaded. One of `community`,`public` or `private. If unset, defaults to `os_images_public` (requires admin permissions for anything other than `private`)
+`os_images_visibility`: The visibility of images uploaded. One of `community`,`public` or `private`. If unset, defaults to `os_images_public` (requires admin permissions for anything other than `private`)
 
 `os_images_venv`: Path to virtualenv in which to install python dependencies to upload images.
 

--- a/roles/os_images/README.md
+++ b/roles/os_images/README.md
@@ -66,8 +66,11 @@ mutually exclusive where each contain:
   be built (even if an existing image that name has been built before). The images on glance
   will be replaced if `os_images_upload` is set to `True`. This defaults to
   `os_images_force_rebuild`if left unset.
-* `is_public`: (optional) whether the image should be set as visible to all
-  projects or kept private.
+* `is_public`: (optional) (deprecated - use `visibility`) whether the image should be set as visible to all
+  projects or kept private. Note that if both `is_public` and `visibility` are provided, `is_public` will 
+  be preferred.
+* `visibility`: (optional) Allowed values are 'public', 'private', 'shared'
+or 'community'. Default is 'public'
 * `owner`: (optional) ID of the project that should own the uploaded image.
 
 `os_images_common`: A set of elements to include in every image listed.
@@ -97,7 +100,9 @@ following parameters:
 will be replaced with the newly built image if `os_images_upload` is set to `True`. Defaults to
 `False`.
 
-`os_images_public`: Whether uploaded images are public. Defaults to `True` - note this requires admin permissions.
+`os_images_public`: (Deprecated - use `os_images_visibility`) Whether uploaded images are public. Defaults to `True` - note this requires admin permissions. 
+
+`os_images_visibility`: The visibility of images uploaded. Defaults to public/private, based off `os_images_public` - note this requires admin permissions.
 
 `os_images_venv`: Path to virtualenv in which to install python dependencies to upload images.
 

--- a/roles/os_images/defaults/main.yml
+++ b/roles/os_images/defaults/main.yml
@@ -98,4 +98,4 @@ os_images_name_suffix:
 os_images_hide: false
 
 # Visibility of images ('public' requires admin rights.)
-os_images_visibility: "{{ 'public' if os_images_public else 'private' }}"
+os_images_visibility: "{{ 'public' if os_images_public | bool else 'private' }}"

--- a/roles/os_images/defaults/main.yml
+++ b/roles/os_images/defaults/main.yml
@@ -15,7 +15,7 @@ os_images_package_state: present
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases. Use Yoga upper constraints
 # otherwise, to avoid incompatibility with openstacksdk 0.99.0.
-os_images_upper_constraints_file: https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}yoga{% endif %}
+os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/2023.1"
 
 # Upper constraints file for installation of DIB to build images.
 os_images_dib_upper_constraints_file: ""
@@ -97,3 +97,6 @@ os_images_build: true
 os_images_name_suffix:
 # Whether or not to hide the images in Glance list
 os_images_hide: false
+
+# Visibility of images ('public' requires admin rights.)
+os_images_visibility: "{{ 'public' if os_images_public else 'private' }}"

--- a/roles/os_images/defaults/main.yml
+++ b/roles/os_images/defaults/main.yml
@@ -9,12 +9,7 @@ os_images_dib_venv: "{{ os_images_venv }}"
 # State of python dependencies.
 os_images_package_state: present
 
-# Upper constraints file for installation of python dependencies to upload
-# images.
-#
-# Use Train upper constraints when running with Python 2, to avoid
-# incompatibility with newer OSC releases. Use Yoga upper constraints
-# otherwise, to avoid incompatibility with openstacksdk 0.99.0.
+# Use Antelope upper constraints as openstacksdk 1.0.1 and openstackclient 6.2.0 are required
 os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/2023.1"
 
 # Upper constraints file for installation of DIB to build images.

--- a/roles/os_images/defaults/main.yml
+++ b/roles/os_images/defaults/main.yml
@@ -10,7 +10,7 @@ os_images_dib_venv: "{{ os_images_venv }}"
 os_images_package_state: present
 
 # Use Antelope upper constraints as openstacksdk 1.0.1 and openstackclient 6.2.0 are required
-os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/2023.1"
+os_images_upper_constraints_file: https://releases.openstack.org/constraints/upper/2023.1
 
 # Upper constraints file for installation of DIB to build images.
 os_images_dib_upper_constraints_file: ""

--- a/roles/os_images/defaults/main.yml
+++ b/roles/os_images/defaults/main.yml
@@ -85,7 +85,7 @@ os_images_public: true
 # Whether or not should new images be promoted
 os_images_promote: false
 
-# Whether or not should old images be retired 
+# Whether or not should old images be retired
 os_images_retire: "{{ os_images_promote }}"
 
 # Whether or not to build the images

--- a/roles/os_images/defaults/main.yml
+++ b/roles/os_images/defaults/main.yml
@@ -82,14 +82,18 @@ os_images_force_rebuild: false
 # Whether images should be public (requires admin rights)
 os_images_public: true
 
-# Whether or not should old images be retired and new images be promoted
+# Whether or not should new images be promoted
 os_images_promote: false
+
+# Whether or not should old images be retired 
+os_images_retire: "{{ os_images_promote }}"
 
 # Whether or not to build the images
 os_images_build: true
 
 # Image suffix which would be removed during image promotion for exmple: -rc, -dev, -test
 os_images_name_suffix:
+
 # Whether or not to hide the images in Glance list
 os_images_hide: false
 

--- a/roles/os_images/meta/main.yml
+++ b/roles/os_images/meta/main.yml
@@ -1,26 +1,4 @@
 ---
-galaxy_info:
-  author: Stig Telfer
-  description: >
-    Role to generate guest instance images and upload to OpenStack
-  company: StackHPC Ltd
-  license: Apache2
-  min_ansible_version: "2.0"
-  platforms:
-    - name: EL
-      versions:
-        - "7"
-    - name: Ubuntu
-      versions:
-        - all
-    - name: Debian
-      versions:
-        - all
-  galaxy_tags:
-    - cloud
-    - keystone
-    - openstack
-
 dependencies:
   - role: stackhpc.openstack.os_openstacksdk
     os_openstacksdk_venv: "{{ os_images_venv }}"

--- a/roles/os_images/tasks/images.yml
+++ b/roles/os_images/tasks/images.yml
@@ -10,7 +10,7 @@
 # The rpm-distro element executes 'semanage' during its cleanup phase.
 - name: Ensure diskimage-builder SELinux dependencies are installed
   vars:
-    package_name: "python3-policycoreutils"
+    package_name: python3-policycoreutils
   ansible.builtin.package:
     name: "{{ package_name }}"
     state: present

--- a/roles/os_images/tasks/images.yml
+++ b/roles/os_images/tasks/images.yml
@@ -10,7 +10,7 @@
 # The rpm-distro element executes 'semanage' during its cleanup phase.
 - name: Ensure diskimage-builder SELinux dependencies are installed
   vars:
-    package_name: "{{ 'policycoreutils-python' if ansible_facts.distribution_major_version | int == 7 else 'python3-policycoreutils' }}"
+    package_name: "python3-policycoreutils"
   ansible.builtin.package:
     name: "{{ package_name }}"
     state: present
@@ -26,7 +26,7 @@
     owner: "{{ ansible_facts.user_uid }}"
     group: "{{ ansible_facts.user_gid }}"
     state: directory
-    mode: "0644"
+    mode: "0755"
   become: true
 
 - name: Remove old images for force rebuild
@@ -45,7 +45,7 @@
     owner: "{{ ansible_facts.user_uid }}"
     group: "{{ ansible_facts.user_gid }}"
     state: directory
-    mode: "0644"
+    mode: "0755"
   with_items: "{{ os_images_list | list }}"
   loop_control:
     label: "{{ item.name }}"

--- a/roles/os_images/tasks/main.yml
+++ b/roles/os_images/tasks/main.yml
@@ -20,4 +20,5 @@
   when: >
     ((os_images_list | selectattr('rename_image', 'defined')) + (os_images_list | selectattr('hide_image', 'defined'))) | list | length > 0
     or (os_images_promote | bool)
+    or (os_images_retire | bool)
     or (os_images_hide | bool)

--- a/roles/os_images/tasks/main.yml
+++ b/roles/os_images/tasks/main.yml
@@ -18,16 +18,6 @@
   vars:
     ansible_python_interpreter: "{{ os_images_venv ~ '/bin/python' if os_images_venv != None else old_ansible_python_interpreter }}"
   when: >
-    (
-      (
-        os_images_list |
-        selectattr('rename_image', 'defined')
-      ) +
-      (
-        os_images_list |
-        selectattr('hide_image', 'defined')
-      )
-    ) |
-    list | length > 0
+    ((os_images_list | selectattr('rename_image', 'defined')) + (os_images_list | selectattr('hide_image', 'defined'))) | list | length > 0
     or (os_images_promote | bool)
     or (os_images_hide | bool)

--- a/roles/os_images/tasks/main.yml
+++ b/roles/os_images/tasks/main.yml
@@ -14,4 +14,17 @@
 - import_tasks: promote.yml
   vars:
     ansible_python_interpreter: "{{ os_images_venv ~ '/bin/python' if os_images_venv != None else old_ansible_python_interpreter }}"
-  when: os_images_promote | bool
+    when: >
+    (
+      (
+        os_images_list |
+        selectattr('rename_image', 'defined')
+      ) +
+      (
+        os_images_list |
+        selectattr('hide_image', 'defined')
+      )
+    ) |
+    list | length > 0
+    or (os_images_promote | bool)
+    or (os_images_hide | bool)

--- a/roles/os_images/tasks/main.yml
+++ b/roles/os_images/tasks/main.yml
@@ -17,7 +17,7 @@
   ansible.builtin.import_tasks: promote.yml
   vars:
     ansible_python_interpreter: "{{ os_images_venv ~ '/bin/python' if os_images_venv != None else old_ansible_python_interpreter }}"
-    when: >
+  when: >
     (
       (
         os_images_list |

--- a/roles/os_images/tasks/main.yml
+++ b/roles/os_images/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set a fact about the Ansible python interpreter
   ansible.builtin.set_fact:
-    old_ansible_python_interpreter: "{{ ansible_python_interpreter | default('/usr/bin/python' + ansible_facts.python.version.major | string) }}"
+    old_ansible_python_interpreter: "{{ ansible_python_interpreter | default('/usr/bin/python3') }}"
 
 - name: Build or download images
   ansible.builtin.import_tasks: images.yml

--- a/roles/os_images/tasks/promote.yml
+++ b/roles/os_images/tasks/promote.yml
@@ -24,9 +24,9 @@
   ansible.builtin.assert:
     that:
       - promotion_name in retire_or_promote.openstack_images | map(attribute='name') | list
-    fail_msg: The image {{ item.name[:-(os_images_name_suffix | length | int)] }} does not exist.
+    fail_msg: "The image {{ item.name[: -(os_images_name_suffix | length | int)] }} does not exist."
   vars:
-    promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] }}"
+    promotion_name: "{{ item.name[: -(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
   when: item.rename_image | default(os_images_promote) | bool
 
@@ -39,19 +39,20 @@
   when: item.rename_image | default(os_images_promote) | bool
 
 - name: Check if image suffix is provided
-  set_fact:
-    image_suffix_provided: "{{ os_images_name_suffix is defined and os_images_name_suffix is not none and (os_images_name_suffix | length > 0) | bool }}"
+  ansible.builtin.set_fact:
+    image_suffix_provided: "{{ os_images_name_suffix is defined and os_images_name_suffix is not none and (os_images_name_suffix | length > 0) }}"
 
-- debug:
+- name: Display info
+  ansible.builtin.debug:
     msg: |
       Warning: no image suffix is provided so retired images are not renamed and candidate images are not promoted.
       Images with the `hide_image` attribute will still be hidden.
-  when: image_suffix_provided == false
+  when: not (image_suffix_provided | bool)
 
 - name: Hide retire candidate images
   ansible.builtin.command: "{{ os_images_venv }}/bin/openstack image set --hidden {{ promotion_name }}"
   vars:
-    promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] if image_suffix_provided else item.name }}"
+    promotion_name: "{{ item.name[: -(os_images_name_suffix | length | int)] if image_suffix_provided else item.name }}"
   with_items: "{{ os_images_list | list }}"
   changed_when: true
   when: (item.hide_image | default(os_images_hide) | bool)
@@ -63,7 +64,7 @@
     promotion_name: "{{ item.name[: -(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
   changed_when: true
-  when: "image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)"
+  when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
   environment: "{{ os_images_venv }}"
 
 - name: Ensure new images are promoted
@@ -72,25 +73,25 @@
     promotion_name: "{{ item.name[: -(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
   changed_when: true
-  when: "image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)"
+  when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
   environment: "{{ os_images_venv }}"
 
-  - name: Discover renamed images
-  set_fact:
+- name: Discover renamed images
+  ansible.builtin.set_fact:
     renaming_message: |
       The following images have been retired:
       {% for item in images %}
-      {{ item.name[:-(os_images_name_suffix | length | int)] }} > {{ item.name[:-(os_images_name_suffix | length | int)] }}.{{ ansible_date_time.date }}
+      {{ item.name[: -(os_images_name_suffix | length | int)] }} > {{ item.name[: -(os_images_name_suffix | length | int)] }}.{{ ansible_date_time.date }}
       {% endfor %}
-      The following images have been promoted: 
+      The following images have been promoted:
       {% for item in images %}
-      {{ item.name }} > {{ item.name[:-(os_images_name_suffix | length | int)] }}
+      {{ item.name }} > {{ item.name[: -(os_images_name_suffix | length | int)] }}
       {% endfor %}
   vars:
     images: "{{ os_images_list | list }}"
   when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
 
-- debug:
+- name: Display info
+  ansible.builtin.debug:
     var: renaming_message
   when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
-  

--- a/roles/os_images/tasks/promote.yml
+++ b/roles/os_images/tasks/promote.yml
@@ -13,12 +13,8 @@
     region_name: "{{ os_images_region | default(omit) }}"
   register: retire_or_promote_list
   when: >
-    (
-      (os_images_list |
-      selectattr('rename_image', 'defined') |
-      list | length > 0)
-      or (os_images_promote | bool)
-    )
+    (os_images_list | selectattr('rename_image', 'defined') | list | length > 0)
+    or (os_images_promote | bool)
 
 - name: Ensure images for retirement exist
   ansible.builtin.assert:

--- a/roles/os_images/tasks/promote.yml
+++ b/roles/os_images/tasks/promote.yml
@@ -4,48 +4,56 @@
     msg: os_images_name_suffix is empty please provide it.
   when: os_images_name_suffix is defined and os_images_name_suffix | length == 0
 
-- name: Gather retire candidates info
+- name: Gather candidates info
   openstack.cloud.image_info:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
     interface: "{{ os_images_interface | default(omit, true) }}"
     region_name: "{{ os_images_region | default(omit) }}"
-  register: retire_list
-  when: item.rename_image | default(os_images_promote) | bool
+  register: retire_or_promote_list
+  when: >
+    (
+      (os_images_list |
+      selectattr('rename_image', 'defined') |
+      list | length > 0)
+      or (os_images_promote | bool)
+    )
 
 - name: Ensure images for retirement exist
   assert:
     that:
-      - item.name in retire_list.openstack_images | map(attribute='name') | list
+      - promotion_name in retire_or_promote.openstack_images | map(attribute='name') | list
     fail_msg: The image {{ item.name[:-(os_images_name_suffix | length | int)] }} does not exist.
+  vars:
+    promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
-  when: item.rename_image | default(os_images_promote) | bool
-
-- name: Gather promote candidates info
-  openstack.cloud.image_info:
-    auth_type: "{{ os_images_auth_type }}"
-    auth: "{{ os_images_auth }}"
-    cacert: "{{ os_images_cacert | default(omit) }}"
-    interface: "{{ os_images_interface | default(omit, true) }}"
-    region_name: "{{ os_images_region | default(omit) }}"
-  register: promote_list
   when: item.rename_image | default(os_images_promote) | bool
 
 - name: Ensure images for promotion exist
   assert:
     that:
-      - item.name in promote_list.openstack_images | map(attribute='name') | list
+      - item.name in retire_or_promote_list.openstack_images | map(attribute='name') | list
     fail_msg: The image {{ item.name }} does not exist.
   loop: "{{ os_images_list | list }}"
   when: item.rename_image | default(os_images_promote) | bool
 
+- name: Check if image suffix is provided
+  set_fact:
+    image_suffix_provided: "{{ os_images_name_suffix is defined and os_images_name_suffix is not none and (os_images_name_suffix | length > 0) | bool }}"
+
+- debug:
+    msg: |
+      Warning: no image suffix is provided so retired images are not renamed and candidate images are not promoted.
+      Images with the `hide_image` attribute will still be hidden.
+  when: image_suffix_provided == false
+
 - name: Hide retire candidate images
   command: "{{ os_images_venv }}/bin/openstack image set --hidden {{ promotion_name }}"
   vars:
-    promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] }}"
+    promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] if image_suffix_provided else item.name }}"
   with_items: "{{ os_images_list | list }}"
-  when: (item.rename_image | default(os_images_promote) | bool) and (item.hide_image | default(os_images_hide) | bool)
+  when: (item.hide_image | default(os_images_hide) | bool)
 
 - name: Ensure old images are retired
   command: "{{ os_images_venv }}/bin/openstack image set {{ promotion_name }} --name {{ promotion_name }}.{{ date_suffix }}"
@@ -53,7 +61,7 @@
     date_suffix: "{{ ansible_date_time.date }}"
     promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
-  when: item.rename_image | default(os_images_promote) | bool
+  when: "image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)"
   environment: "{{ os_images_venv }}"
 
 - name: Ensure new images are promoted
@@ -61,5 +69,25 @@
   vars:
     promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
-  when: item.rename_image | default(os_images_promote) | bool
+  when: "image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)"
   environment: "{{ os_images_venv }}"
+
+  - name: Discover renamed images
+  set_fact:
+    renaming_message: |
+      The following images have been retired:
+      {% for item in images %}
+      {{ item.name[:-(os_images_name_suffix | length | int)] }} > {{ item.name[:-(os_images_name_suffix | length | int)] }}.{{ ansible_date_time.date }}
+      {% endfor %}
+      The following images have been promoted: 
+      {% for item in images %}
+      {{ item.name }} > {{ item.name[:-(os_images_name_suffix | length | int)] }}
+      {% endfor %}
+  vars:
+    images: "{{ os_images_list | list }}"
+  when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
+
+- debug:
+    var: renaming_message
+  when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
+  

--- a/roles/os_images/tasks/promote.yml
+++ b/roles/os_images/tasks/promote.yml
@@ -80,10 +80,6 @@
       {% for item in images %}
       {{ item.name[: -(os_images_name_suffix | length | int)] }} > {{ item.name[: -(os_images_name_suffix | length | int)] }}.{{ ansible_date_time.date }}
       {% endfor %}
-      The following images have been promoted:
-      {% for item in images %}
-      {{ item.name }} > {{ item.name[: -(os_images_name_suffix | length | int)] }}
-      {% endfor %}
   vars:
     images: "{{ os_images_list | list }}"
   when: image_suffix_provided and (item.rename_image | default(os_images_retire) | bool)

--- a/roles/os_images/tasks/promote.yml
+++ b/roles/os_images/tasks/promote.yml
@@ -23,7 +23,7 @@
 - name: Ensure images for retirement exist
   ansible.builtin.assert:
     that:
-      - promotion_name in retire_or_promote.openstack_images | map(attribute='name') | list
+      - promotion_name in retire_or_promote_list.openstack_images | map(attribute='name') | list
     fail_msg: "The image {{ item.name[: -(os_images_name_suffix | length | int)] }} does not exist."
   vars:
     promotion_name: "{{ item.name[: -(os_images_name_suffix | length | int)] }}"

--- a/roles/os_images/tasks/promote.yml
+++ b/roles/os_images/tasks/promote.yml
@@ -15,6 +15,7 @@
   when: >
     (os_images_list | selectattr('rename_image', 'defined') | list | length > 0)
     or (os_images_promote | bool)
+    or (os_images_retire | bool)
 
 - name: Ensure images for retirement exist
   ansible.builtin.assert:
@@ -24,7 +25,7 @@
   vars:
     promotion_name: "{{ item.name[: -(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
-  when: item.rename_image | default(os_images_promote) | bool
+  when: item.rename_image | default(os_images_retire) | bool
 
 - name: Ensure images for promotion exist
   ansible.builtin.assert:
@@ -60,7 +61,7 @@
     promotion_name: "{{ item.name[: -(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
   changed_when: true
-  when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
+  when: image_suffix_provided and (item.rename_image | default(os_images_retire) | bool)
   environment: "{{ os_images_venv }}"
 
 - name: Ensure new images are promoted
@@ -72,9 +73,9 @@
   when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
   environment: "{{ os_images_venv }}"
 
-- name: Discover renamed images
+- name: Discover retired images
   ansible.builtin.set_fact:
-    renaming_message: |
+    retire_message: |
       The following images have been retired:
       {% for item in images %}
       {{ item.name[: -(os_images_name_suffix | length | int)] }} > {{ item.name[: -(os_images_name_suffix | length | int)] }}.{{ ansible_date_time.date }}
@@ -85,9 +86,25 @@
       {% endfor %}
   vars:
     images: "{{ os_images_list | list }}"
+  when: image_suffix_provided and (item.rename_image | default(os_images_retire) | bool)
+
+- name: Display info
+  ansible.builtin.debug:
+    var: retire_message
+  when: image_suffix_provided and (item.rename_image | default(os_images_retire) | bool)
+
+- name: Discover promoted images
+  ansible.builtin.set_fact:
+    promote_message: |
+      The following images have been promoted:
+      {% for item in images %}
+      {{ item.name }} > {{ item.name[: -(os_images_name_suffix | length | int)] }}
+      {% endfor %}
+  vars:
+    images: "{{ os_images_list | list }}"
   when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
 
 - name: Display info
   ansible.builtin.debug:
-    var: renaming_message
+    var: promote_message
   when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)

--- a/roles/os_images/tasks/promote.yml
+++ b/roles/os_images/tasks/promote.yml
@@ -20,7 +20,7 @@
 - name: Ensure images for retirement exist
   ansible.builtin.assert:
     that:
-      - promotion_name in retire_or_promote_list.openstack_images | map(attribute='name') | list
+      - promotion_name in retire_or_promote_list.images | map(attribute='name') | list
     fail_msg: "The image {{ item.name[: -(os_images_name_suffix | length | int)] }} does not exist."
   vars:
     promotion_name: "{{ item.name[: -(os_images_name_suffix | length | int)] }}"
@@ -30,7 +30,7 @@
 - name: Ensure images for promotion exist
   ansible.builtin.assert:
     that:
-      - item.name in retire_or_promote_list.openstack_images | map(attribute='name') | list
+      - item.name in retire_or_promote_list.images | map(attribute='name') | list
     fail_msg: The image {{ item.name }} does not exist.
   loop: "{{ os_images_list | list }}"
   when: item.rename_image | default(os_images_promote) | bool

--- a/roles/os_images/tasks/upload.yml
+++ b/roles/os_images/tasks/upload.yml
@@ -31,7 +31,7 @@
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
   with_items: "{{ os_images_list | list }}"
-  vars: 
+  vars:
     visibility: "{{ item.visibility | default(item.is_public | ternary('public', 'private') if item.is_public is defined else os_images_visibility) }}"
   loop_control:
     label: "{{ item.name }}"
@@ -72,7 +72,7 @@
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
   with_items: "{{ os_images_list | list }}"
-  vars: 
+  vars:
     visibility: "{{ item.visibility | default(item.is_public | ternary('public', 'private') if item.is_public is defined else os_images_visibility) }}"
   loop_control:
     label: "{{ item.name }}"

--- a/roles/os_images/tasks/upload.yml
+++ b/roles/os_images/tasks/upload.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure existing cloud tenant kernel does not exist
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -18,7 +18,7 @@
   tags: clean
 
 - name: Upload cloud tenant kernel for baremetal images
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -26,11 +26,13 @@
     region_name: "{{ os_images_region | default(omit) }}"
     name: "{{ item.name ~ '-kernel' }}"
     state: present
-    is_public: "{{ item.is_public | default(os_images_public) | bool }}"
+    visibility: "{{ visibility | default(os_images_visibility) }}"
     container_format: aki
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
   with_items: "{{ os_images_list | list }}"
+  vars: 
+    visibility: "{{ item.visibility | default(item.is_public | ternary('public', 'private') if item.is_public is defined else os_images_visibility) }}"
   loop_control:
     label: "{{ item.name }}"
   when:
@@ -39,7 +41,7 @@
   register: kernel_result
 
 - name: Ensure existing cloud tenant ramdisk does not exist
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -57,7 +59,7 @@
   tags: clean
 
 - name: Upload cloud tenant ramdisk for baremetal images
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -65,11 +67,13 @@
     region_name: "{{ os_images_region | default(omit) }}"
     name: "{{ item.name ~ '-ramdisk' }}"
     state: present
-    is_public: "{{ item.is_public | default(os_images_public) | bool }}"
+    visibility: "{{ visibility | default(os_images_visibility) }}"
     container_format: ari
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
   with_items: "{{ os_images_list | list }}"
+  vars: 
+    visibility: "{{ item.visibility | default(item.is_public | ternary('public', 'private') if item.is_public is defined else os_images_visibility) }}"
   loop_control:
     label: "{{ item.name }}"
   when:
@@ -78,7 +82,7 @@
   register: ramdisk_result
 
 - name: Ensure existing cloud tenant image does not exist
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -93,7 +97,7 @@
   tags: clean
 
 - name: Upload cloud tenant images
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -101,7 +105,7 @@
     region_name: "{{ os_images_region | default(omit) }}"
     name: "{{ item.0.name }}"
     state: present
-    is_public: "{{ item.0.is_public | default(os_images_public) | bool }}"
+    visibility: "{{ visibility | default(os_images_visibility) }}"
     owner: "{{ item.0.owner | default(omit) }}"
     container_format: bare
     disk_format: "{{ item.0.type | default('qcow2') }}"
@@ -111,6 +115,7 @@
     ramdisk: "{{ item.2.id if is_baremetal else omit }}"
   vars:
     is_baremetal: "{{ item.0.elements is defined and 'baremetal' in item.0.elements }}"
+    visibility: "{{ item.0.visibility | default(item.0.is_public | ternary('public', 'private') if item.0.is_public is defined else os_images_visibility) }}"
   with_together:
     - "{{ os_images_list | list }}"
     - "{{ kernel_result.results }}"

--- a/roles/os_images/tasks/upload.yml
+++ b/roles/os_images/tasks/upload.yml
@@ -26,7 +26,7 @@
     region_name: "{{ os_images_region | default(omit) }}"
     name: "{{ item.name ~ '-kernel' }}"
     state: present
-    visibility: "{{ visibility | default(os_images_visibility) }}"
+    visibility: "{{ visibility }}"
     container_format: aki
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
@@ -67,7 +67,7 @@
     region_name: "{{ os_images_region | default(omit) }}"
     name: "{{ item.name ~ '-ramdisk' }}"
     state: present
-    visibility: "{{ visibility | default(os_images_visibility) }}"
+    visibility: "{{ visibility }}"
     container_format: ari
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
@@ -105,7 +105,7 @@
     region_name: "{{ os_images_region | default(omit) }}"
     name: "{{ item.0.name }}"
     state: present
-    visibility: "{{ visibility | default(os_images_visibility) }}"
+    visibility: "{{ visibility }}"
     owner: "{{ item.0.owner | default(omit) }}"
     container_format: bare
     disk_format: "{{ item.0.type | default('qcow2') }}"


### PR DESCRIPTION
The following changes enable our kubernetes images to be deployed and retired as part of the new magnum/azimuth image and template pipeline:

- the `is_public` property is deprecated, and a `visibility` property is added, which allows for images to be `public`, `private`, `community` or `shared` (although nothing is done if `shared` is used at the moment, it will be set to `private`). if `visibility` is not set, the image will default to `public`, the same as before.
- images can be hidden even if there is no renaming to be done. This is the case for kubernetes images, as there are no release candidates because images are tested before uploading, but old images do need to be hidden. The behaviour for the previous retire/promote workflow remains the same.
- `os_images_retire` is added, allowing images to be promoted and retired separately. This may be useful for example if an image is being deprecated with no image promoted to replace it, or a candidate image for a new distribution has been tested and is ready to promote, but is not replacing anything. default value is `os_images_promote`.
- Additionally some duplication is removed, the check for whether images to be retired exist has been fixed (I think), and some output at the end of the run detailing which images have been promoted or retired is given, which might be useful to verify if any mistakes were made.

original discussion here: https://github.com/stackhpc/ansible-role-os-images/pull/77