### PR TITLE
Unify upper constraints to 2023.1 Antelope

### DIFF
--- a/roles/os_container_clusters/defaults/main.yml
+++ b/roles/os_container_clusters/defaults/main.yml
@@ -9,7 +9,7 @@ os_container_clusters_auth: {}
 # mapping container cluster template attribute names to their values.
 os_container_clusters_templates: []
 # Upper constraints file for installation of python dependencies.
-os_container_clusters_upper_constraints_file:
+os_container_clusters_upper_constraints_file: https://releases.openstack.org/constraints/upper/2023.1
 # Whether to make templates public
 os_container_clusters_public: false
 # Whether to hide templates by default

--- a/roles/os_deploy_templates/defaults/main.yml
+++ b/roles/os_deploy_templates/defaults/main.yml
@@ -2,12 +2,8 @@
 # Path to a directory in which to create a virtualenv.
 os_deploy_templates_venv:
 
-# Upper constraints file for installation of python dependencies.
-#
-# Use Yoga upper constraints, to avoid incompatibility with openstacksdk
-# 0.99.0 and include support for deploy templates (included since openstacksdk
-# 0.53).
-os_deploy_templates_upper_constraints_file: https://releases.openstack.org/constraints/upper/yoga
+# Upper constraints file for installation of Python dependencies.
+os_deploy_templates_upper_constraints_file: https://releases.openstack.org/constraints/upper/2023.1
 
 # Authentication type.
 os_deploy_templates_auth_type:

--- a/roles/os_openstackclient/defaults/main.yml
+++ b/roles/os_openstackclient/defaults/main.yml
@@ -10,4 +10,4 @@ os_openstackclient_state: present
 # Version of python-openstackclient to install, or unrestricted if empty.
 os_openstackclient_version:
 # Upper constraints file for installation of openstackclient.
-os_openstackclient_upper_constraints_file:
+os_openstackclient_upper_constraints_file: https://releases.openstack.org/constraints/upper/2023.1

--- a/roles/os_openstacksdk/defaults/main.yml
+++ b/roles/os_openstacksdk/defaults/main.yml
@@ -13,4 +13,4 @@ os_openstacksdk_state: present
 # Version of openstacksdk to install, or unrestricted if empty.
 os_openstacksdk_version:
 # Upper constraints file for installation of openstacksdk.
-os_openstacksdk_upper_constraints_file:
+os_openstacksdk_upper_constraints_file: https://releases.openstack.org/constraints/upper/2023.1

--- a/roles/os_projects/README.md
+++ b/roles/os_projects/README.md
@@ -77,7 +77,7 @@ resources.
       roles:
         - role: stackhpc.openstack.os_projects
           os_projects_venv: "~/os-projects-venv"
-          os_projects_upper_constraints: "https://opendev.org/openstack/requirements/raw/branch/stable/2023.1/upper-constraints.txt"
+          os_projects_upper_constraints: "https://releases.openstack.org/constraints/upper/2023.1"
           os_projects_auth_type: "password"
           os_projects_auth:
             project_name: <keystone project>

--- a/roles/os_projects/defaults/main.yml
+++ b/roles/os_projects/defaults/main.yml
@@ -38,4 +38,4 @@ os_projects_domains: []
 #   - 'public_key_file': Path to the SSH public key on the control host.
 # 'quotas': Optional dict mapping quota names to their values.
 os_projects: [] # noqa var-naming[no-role-prefix]
-os_projects_upper_constraints:
+os_projects_upper_constraints: https://releases.openstack.org/constraints/upper/2023.1

--- a/roles/os_volumes/README.md
+++ b/roles/os_volumes/README.md
@@ -41,6 +41,9 @@ dict containing the following items:
 - `extra_specs`: Optional dict of additional specifications for the volume
   type.
 
+`os_volumes_upper_constraints_file` is a file or URL containing Python upper
+constraints.
+
 Dependencies
 ------------
 

--- a/roles/os_volumes/defaults/main.yml
+++ b/roles/os_volumes/defaults/main.yml
@@ -32,3 +32,6 @@ os_volumes: [] # noqa: var-naming[no-role-prefix]
 # - 'extra_specs': Optional dict of additional specifications for the volume
 #   type.
 os_volumes_types: []
+
+# A file or URL containing Python upper constraints.
+os_volumes_upper_constraints_file:

--- a/roles/os_volumes/defaults/main.yml
+++ b/roles/os_volumes/defaults/main.yml
@@ -34,4 +34,4 @@ os_volumes: [] # noqa: var-naming[no-role-prefix]
 os_volumes_types: []
 
 # A file or URL containing Python upper constraints.
-os_volumes_upper_constraints_file:
+os_volumes_upper_constraints_file: https://releases.openstack.org/constraints/upper/2023.1

--- a/roles/os_volumes/meta/main.yml
+++ b/roles/os_volumes/meta/main.yml
@@ -2,5 +2,7 @@
 dependencies:
   - role: stackhpc.openstack.os_openstacksdk
     os_openstacksdk_venv: "{{ os_volumes_venv }}"
+    os_openstacksdk_upper_constraints_file: "{{ os_volumes_upper_constraints_file }}"
   - role: stackhpc.openstack.os_openstackclient
     os_openstackclient_venv: "{{ os_volumes_venv }}"
+    os_openstackclient_upper_constraints_file: "{{ os_volumes_upper_constraints_file }}"


### PR DESCRIPTION
This provides openstacksdk > 1.0, which is required for openstack.cloud modules.
