### PR TITLE
Implement workaround for router name lookup bug

### DIFF
--- a/roles/os_networks/tasks/networks.yml
+++ b/roles/os_networks/tasks/networks.yml
@@ -80,13 +80,13 @@
 
 # Workaround bug https://bugs.launchpad.net/ansible-collections-openstack/+bug/2049658
 # by looking up external network information using networks_info and then explicitly
-# passing the network ID into the openstack.cloud.router. Remove this workaround and 
+# passing the network ID into the openstack.cloud.router. Remove this workaround and
 # uncomment code above when bug is fixed.
 
 - name: Ensure router is registered with neutron
   # Can't loop over blocks in Ansible so have to
   # include separate tasks file instead :(
-  include_tasks: router_workaround.yml
+  ansible.builtin.include_tasks: router_workaround.yml
   with_items: "{{ os_networks_routers }}"
   when: item.state | default('present') == 'present'
 

--- a/roles/os_networks/tasks/networks.yml
+++ b/roles/os_networks/tasks/networks.yml
@@ -62,19 +62,31 @@
     - "{{ os_networks }}"
     - subnets
 
+# - name: Ensure router is registered with neutron
+#   openstack.cloud.router:
+#     auth_type: "{{ os_networks_auth_type }}"
+#     auth: "{{ os_networks_auth }}"
+#     cacert: "{{ os_networks_cacert | default(omit) }}"
+#     cloud: "{{ os_networks_cloud | default(omit) }}"
+#     interface: "{{ os_networks_interface | default(omit, true) }}"
+#     name: "{{ item.name }}"
+#     interfaces: "{{ item.interfaces | default(omit) }}"
+#     network: "{{ item.network }}"
+#     external_fixed_ips: "{{ item.external_fixed_ips | default(omit) }}"
+#     project: "{{ item.project | default(omit) }}"
+#     state: "{{ item.state | default(omit) }}"
+#   loop: "{{ os_networks_routers }}"
+#   when: item.state | default('present') == 'present'
+
+# Workaround bug https://bugs.launchpad.net/ansible-collections-openstack/+bug/2049658
+# by looking up external network information using networks_info and then explicitly
+# passing the network ID into the openstack.cloud.router. Remove this workaround and 
+# uncomment code above when bug is fixed.
+
 - name: Ensure router is registered with neutron
-  openstack.cloud.router:
-    auth_type: "{{ os_networks_auth_type }}"
-    auth: "{{ os_networks_auth }}"
-    cacert: "{{ os_networks_cacert | default(omit) }}"
-    cloud: "{{ os_networks_cloud | default(omit) }}"
-    interface: "{{ os_networks_interface | default(omit, true) }}"
-    name: "{{ item.name }}"
-    interfaces: "{{ item.interfaces | default(omit) }}"
-    network: "{{ item.network | default(omit) }}"
-    external_fixed_ips: "{{ item.external_fixed_ips | default(omit) }}"
-    project: "{{ item.project | default(omit) }}"
-    state: "{{ item.state | default(omit) }}"
+  # Can't loop over blocks in Ansible so have to
+  # include separate tasks file instead :(
+  include_tasks: router_workaround.yml
   with_items: "{{ os_networks_routers }}"
   when: item.state | default('present') == 'present'
 

--- a/roles/os_networks/tasks/router_workaround.yml
+++ b/roles/os_networks/tasks/router_workaround.yml
@@ -3,7 +3,7 @@
 # passing the network ID into the openstack.cloud.router's network field.
 
 # NOTE: When the item.network parameter is an ID then we are effectively querying a
-# network by ID just to extract it's ID... but since the 'name' field of 
+# network by ID just to extract it's ID... but since the 'name' field of
 # openstack.cloud.networks_info makes no distinction between names and IDs we can't
 # really avoid this.
 

--- a/roles/os_networks/tasks/router_workaround.yml
+++ b/roles/os_networks/tasks/router_workaround.yml
@@ -1,0 +1,27 @@
+# Workaround bug https://bugs.launchpad.net/ansible-collections-openstack/+bug/2049658
+# by looking up external network information using networks_info and then explicitly
+# passing the network ID into the openstack.cloud.router's network field.
+
+# NOTE: When the item.network parameter is an ID then we are effectively querying a
+# network by ID just to extract it's ID... but since the 'name' field of 
+# openstack.cloud.networks_info makes no distinction between names and IDs we can't
+# really avoid this.
+
+- name: Fetch external network information
+  openstack.cloud.networks_info:
+    name: "{{ item.network }}"
+  register: _networks_query
+
+- name: Ensure router is registered with neutron
+  openstack.cloud.router:
+    auth_type: "{{ os_networks_auth_type }}"
+    auth: "{{ os_networks_auth }}"
+    cacert: "{{ os_networks_cacert | default(omit) }}"
+    cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
+    name: "{{ item.name }}"
+    interfaces: "{{ item.interfaces | default(omit) }}"
+    network: "{{ _networks_query.networks[0].id }}"
+    external_fixed_ips: "{{ item.external_fixed_ips | default(omit) }}"
+    project: "{{ item.project | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"

--- a/roles/os_networks/tasks/router_workaround.yml
+++ b/roles/os_networks/tasks/router_workaround.yml
@@ -10,6 +10,11 @@
 - name: Fetch external network information
   openstack.cloud.networks_info:
     name: "{{ item.network }}"
+    auth_type: "{{ os_networks_auth_type }}"
+    auth: "{{ os_networks_auth }}"
+    cacert: "{{ os_networks_cacert | default(omit) }}"
+    cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
   register: _networks_query
 
 - name: Ensure router is registered with neutron


### PR DESCRIPTION
Workaround for https://bugs.launchpad.net/ansible-collections-openstack/+bug/2049658 since proposed patch has stalled and this bug is blocking the use of this ansible collection in openstack-config and therefore also blocking Magnum-related PRs for openstack-config.