### PR TITLE
Match os-projects upper constraints naming scheme

### DIFF
--- a/roles/os_projects/README.md
+++ b/roles/os_projects/README.md
@@ -56,7 +56,7 @@ Each item should be a dict containing the following items:
   - `public_key_file`: Path to the SSH public key on the control host.
 - `quotas`: Optional dict mapping quota names to their values.
 
-`os_projects_upper_constraints` is a path to an upper constraints file which
+`os_projects_upper_constraints_file` is a path to an upper constraints file which
 is passed through to the role dependencies.
 
 Dependencies
@@ -77,7 +77,7 @@ resources.
       roles:
         - role: stackhpc.openstack.os_projects
           os_projects_venv: "~/os-projects-venv"
-          os_projects_upper_constraints: "https://releases.openstack.org/constraints/upper/2023.1"
+          os_projects_upper_constraints_file: "https://releases.openstack.org/constraints/upper/2023.1"
           os_projects_auth_type: "password"
           os_projects_auth:
             project_name: <keystone project>

--- a/roles/os_projects/defaults/main.yml
+++ b/roles/os_projects/defaults/main.yml
@@ -38,4 +38,4 @@ os_projects_domains: []
 #   - 'public_key_file': Path to the SSH public key on the control host.
 # 'quotas': Optional dict mapping quota names to their values.
 os_projects: [] # noqa var-naming[no-role-prefix]
-os_projects_upper_constraints: https://releases.openstack.org/constraints/upper/2023.1
+os_projects_upper_constraints_file: https://releases.openstack.org/constraints/upper/2023.1

--- a/roles/os_projects/meta/main.yml
+++ b/roles/os_projects/meta/main.yml
@@ -2,8 +2,9 @@
 dependencies:
   - role: stackhpc.openstack.os_openstacksdk
     os_openstacksdk_venv: "{{ os_projects_venv }}"
-    os_openstacksdk_upper_constraints_file: "{{ os_projects_upper_constraints | default(None) }}"
+    # Keep support for old naming scheme ``os_projects_upper_constraints``.
+    os_openstacksdk_upper_constraints_file: "{{ os_projects_upper_constraints_file | default(os_projects_upper_constraints) | default(None) }}"
 
   - role: stackhpc.openstack.os_openstackclient
     os_openstackclient_venv: "{{ os_projects_venv }}"
-    os_openstackclient_upper_constraints_file: "{{ os_projects_upper_constraints | default(None) }}"
+    os_openstackclient_upper_constraints_file: "{{ os_projects_upper_constraints_file | default(os_projects_upper_constraints) | default(None) }}"


### PR DESCRIPTION
All roles except os-projects use the naming scheme ``os_*_upper_constraints_file`` for setting upper constraints. Add the suffix ``_file`` to os-projects too so all roles are consistent. Backwards compatibility is maintained.