### PR TITLE
os_projects: Remove fixed_ips quota

### DIFF
--- a/roles/os_projects/tasks/projects.yml
+++ b/roles/os_projects/tasks/projects.yml
@@ -184,7 +184,6 @@
     backup_gigabytes: "{{ quotas.backup_gigabytes | default(omit) }}"
     backups: "{{ quotas.backups | default(omit) }}"
     cores: "{{ quotas.cores | default(omit) }}"
-    fixed_ips: "{{ quotas.fixed_ips | default(omit) }}"
     floating_ips: "{{ quotas.floating_ips | default(omit) }}"
     floatingip: "{{ quotas.floatingip | default(omit) }}"
     gigabytes: "{{ quotas.gigabytes | default(omit) }}"


### PR DESCRIPTION
This was only supported until Nova API 2.35.
