### PR TITLE
os_images visibility fix

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: stackhpc
 name: openstack
-version: 0.2.1
+version: 0.2.2
 readme: README.md
 authors:
   - StackHPC Ltd

--- a/roles/os_images/tasks/upload.yml
+++ b/roles/os_images/tasks/upload.yml
@@ -32,7 +32,7 @@
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
   with_items: "{{ os_images_list | list }}"
   vars:
-    visibility: "{{ item.visibility | default(item.is_public | ternary('public', 'private') if item.is_public is defined else os_images_visibility) }}"
+    visibility: "{{ os_images_visibility | default(item.0.visibility | default(item.0.is_public | default(true) | ternary('public', 'private', true))) }}"
   loop_control:
     label: "{{ item.name }}"
   when:
@@ -73,7 +73,7 @@
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
   with_items: "{{ os_images_list | list }}"
   vars:
-    visibility: "{{ item.visibility | default(item.is_public | ternary('public', 'private') if item.is_public is defined else os_images_visibility) }}"
+    visibility: "{{ os_images_visibility | default(item.0.visibility | default(item.0.is_public | default(true) | ternary('public', 'private', true))) }}"
   loop_control:
     label: "{{ item.name }}"
   when:
@@ -115,7 +115,7 @@
     ramdisk: "{{ item.2.id if is_baremetal else omit }}"
   vars:
     is_baremetal: "{{ item.0.elements is defined and 'baremetal' in item.0.elements }}"
-    visibility: "{{ item.0.visibility | default(item.0.is_public | ternary('public', 'private') if item.0.is_public is defined else os_images_visibility) }}"
+    visibility: "{{ os_images_visibility | default(item.0.visibility | default(item.0.is_public | default(true) | ternary('public', 'private', true))) }}"
   with_together:
     - "{{ os_images_list | list }}"
     - "{{ kernel_result.results }}"


### PR DESCRIPTION
Correcting visibility variable logic, to account for edge case when ```is_public``` is defined but we want to override it with ```os_images_visibility```.

Based on discussions here:
https://github.com/stackhpc/ansible-role-os-images/pull/77#discussion_r1289815546
It looks like the intention was to support deprecated ```is_public``` along with ```visibility``` and still have the ability to override with role defined ```os_images_visibility```.

This PR handles that.

Fixes : https://github.com/stackhpc/ansible-collection-openstack/issues/37

