### PR TITLE
os_images: Install git when there are elements in git repos

### DIFF
--- a/roles/os_images/vars/Debian.yml
+++ b/roles/os_images/vars/Debian.yml
@@ -3,6 +3,7 @@
 os_images_package_dependencies:
   - dosfstools
   - gdisk
+  - "{% if os_images_git_elements | length > 0 %}git{% endif %}"
   - kpartx
   - lvm2
   - qemu-utils

--- a/roles/os_images/vars/RedHat.yml
+++ b/roles/os_images/vars/RedHat.yml
@@ -3,6 +3,7 @@
 os_images_package_dependencies:
   - dosfstools
   - gdisk
+  - "{% if os_images_git_elements | length > 0 %}git{% endif %}"
   - kpartx
   - lvm2
   - qemu-img


### PR DESCRIPTION
Without this change the task 'Git clone any additional image element
repos' will fail if git is not installed.
