### PR TITLE
Create RBAC policies before routers

### DIFF
--- a/roles/os_networks/tasks/networks.yml
+++ b/roles/os_networks/tasks/networks.yml
@@ -62,6 +62,10 @@
     - "{{ os_networks }}"
     - subnets
 
+- name: Include rbac.yml
+  ansible.builtin.include_tasks: rbac.yml
+  when: os_networks_rbac | length > 0
+
 # - name: Ensure router is registered with neutron
 #   openstack.cloud.router:
 #     auth_type: "{{ os_networks_auth_type }}"
@@ -124,7 +128,3 @@
   with_subelements:
     - "{{ os_networks_security_groups }}"
     - rules
-
-- name: Include rbac.yml
-  ansible.builtin.include_tasks: rbac.yml
-  when: os_networks_rbac | length > 0


### PR DESCRIPTION
RBAC policy may be used to set a network as external, and routers may only be connected to external networks. If an RBAC policy affects a network to be added to a router, ensure that the policy is applied before the router is created.