### PR TITLE
Support routers without an external gateway

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: stackhpc
 name: openstack
-version: 0.2.1
+version: 0.2.2
 readme: README.md
 authors:
   - StackHPC Ltd

--- a/roles/os_networks/tasks/router_workaround.yml
+++ b/roles/os_networks/tasks/router_workaround.yml
@@ -16,6 +16,7 @@
     cloud: "{{ os_networks_cloud | default(omit) }}"
     interface: "{{ os_networks_interface | default(omit, true) }}"
   register: _networks_query
+  when: item.network is defined
 
 - name: Ensure router is registered with neutron
   openstack.cloud.router:
@@ -26,7 +27,7 @@
     interface: "{{ os_networks_interface | default(omit, true) }}"
     name: "{{ item.name }}"
     interfaces: "{{ item.interfaces | default(omit) }}"
-    network: "{{ _networks_query.networks[0].id }}"
+    network: "{{ _networks_query.networks[0].id if _networks_query is not skipped else omit }}"
     external_fixed_ips: "{{ item.external_fixed_ips | default(omit) }}"
     project: "{{ item.project | default(omit) }}"
     state: "{{ item.state | default(omit) }}"


### PR DESCRIPTION
Sometimes we may want to create routers that do not have an external
gateway. This was possible before the router workaround was applied in
0ed105fad14732adec2879995f16ca13a7bc4826.

This change makes it possible to define a router without a 'network'
attribute.
