### PR TITLE
Make user password optional

### DIFF
--- a/roles/os_projects/README.md
+++ b/roles/os_projects/README.md
@@ -44,7 +44,8 @@ Each item should be a dict containing the following items:
   - `name`: The name of the user.
   - `description`: User name/description (optional)
   - `email`: User email address (optional)
-  - `password`: The user's password. This is not updated after creation.
+  - `password`: The user's password (optional). This is not updated after
+    creation.
   - `roles`: Optional list of roles to assign to the user in the project.
   - `domain_roles`: Optional list of roles to assign to the user in the user
     domain.

--- a/roles/os_projects/tasks/users.yml
+++ b/roles/os_projects/tasks/users.yml
@@ -9,7 +9,7 @@
     name: "{{ item.name }}"
     description: "{{ item.description | default(omit) }}"
     email: "{{ item.email | default(omit) }}"
-    password: "{{ item.password }}"
+    password: "{{ item.password | default(omit) }}"
     default_project: "{{ project.name }}"
     domain: "{{ domain_is_id | ternary(project.user_domain, os_projects_domain_to_id[project.user_domain]) }}"
     state: present


### PR DESCRIPTION
This appears to be supported by openstack.cloud.identity_user [1].

[1] https://docs.ansible.com/ansible/latest/collections/openstack/cloud/identity_user_module.html