### PR TITLE
os_images: rc assert bug fix

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: stackhpc
 name: openstack
-version: 0.2.3
+version: 0.2.4
 readme: README.md
 authors:
   - StackHPC Ltd

--- a/roles/os_images/tasks/prechecks.yml
+++ b/roles/os_images/tasks/prechecks.yml
@@ -10,7 +10,7 @@
 - name: Display warning message about the container engine
   ansible.builtin.assert:
     that:
-      - result.rc = 0
+      - result.rc == 0
     fail_msg: >
       Container runtime engine could not be found - make sure it is installed.
       Elements that depend on it will likely fail when building.


### PR DESCRIPTION
```
TASK [stackhpc.openstack.os_images : Display warning message about the container engine] *************************************************************************************************************************************************************************************************************************************
task path: /home/rocky/deployment/src/openstack-config/ansible/collections/ansible_collections/stackhpc/openstack/roles/os_images/tasks/prechecks.yml:10
Wednesday 06 November 2024  11:09:52 +0100 (0:00:00.227)       0:00:08.409 ****
fatal: [localhost]: FAILED! =>
  msg: 'The conditional check ''result.rc = 0'' failed. The error was: template error while templating string: expected token ''end of statement block'', got ''=''. String: {% if result.rc = 0 %} True {% else %} False {% endif %}'
  ```