### PR TITLE
add flavor to project mapping

### DIFF
--- a/roles/os_flavors/README.md
+++ b/roles/os_flavors/README.md
@@ -1,8 +1,8 @@
 OpenStack Flavors
 =================
 
-This role can be used to register flavors in Nova using the
-`openstack.cloud.compute_flavor` module.
+This role can be used to register flavors in Nova and map them to projects
+using the `openstack.cloud.compute_flavor` module.
 
 Requirements
 ------------
@@ -31,6 +31,15 @@ containing the items 'name', 'ram', 'disk', and 'vcpus'. Optionally, the dict
 may contain 'ephemeral', 'flavorid', 'rxtx_factor' and 'swap' items.
 Optionally, the dict may also contain an item 'extra_specs', which is a dict of
 metadata to attach to the flavor object.
+
+`is_public` is a mandatory parameter when mapping flavor to project. Non public 
+flavor can't be mapped. However there is possibility to create flavor which 
+is private and not mapped to any project. Only 'true' and 'false' are 
+allowed here.
+
+`project` list of project to which flavor should be mapped. In other 
+words: this flavor will be visible and usable only in said project. It is
+ a dict, withpossible one element.
 
 Dependencies
 ------------
@@ -62,6 +71,25 @@ The following playbook registers a Nova flavor.
               extra_specs:
                 hw:cpu_policy: "dedicated"
                 hw:numa_nodes: "1"
+
+The following playbook will allow uasge of `flavor-1` only in project `projectA`.
+
+    ---
+    - name: Map Nova flavors to projects
+      hosts: localhost
+      roles:
+        - role: openstack.cloud.compute_flavor_access
+          os_flavors_venv: "~/os-flavors-venv"
+          os_flavors_auth_type: "password"
+          os_flavors_auth:
+            project_name: <keystone project>
+            username: <keystone user>
+            password: <keystone password>
+            auth_url: <keystone auth URL>
+          os_flavors:
+            - name: flavor-1
+              state: private
+              project: "projectA"
 
 Author Information
 ------------------

--- a/roles/os_flavors/README.md
+++ b/roles/os_flavors/README.md
@@ -38,9 +38,9 @@ flavor can't be mapped.  However there is possibility to create flavor which
 is private and not mapped to any project. Only 'true' and 'false' are 
 allowed here.
 
-`project` list of project to which flavor should be mapped. In other 
-words: this flavor will be visible and usable only in said project. It is
-a dict, with possible one element.
+`project` single value, or list of projects, to which flavor should be mapped. 
+In other words: this flavor will be visible and usable only in said project(s).
+
 
 Dependencies
 ------------

--- a/roles/os_flavors/README.md
+++ b/roles/os_flavors/README.md
@@ -32,14 +32,15 @@ may contain 'ephemeral', 'flavorid', 'rxtx_factor' and 'swap' items.
 Optionally, the dict may also contain an item 'extra_specs', which is a dict of
 metadata to attach to the flavor object.
 
-`is_public` is a mandatory parameter when mapping flavor to project. Non public 
-flavor can't be mapped. However there is possibility to create flavor which 
+`is_public` default is `true`. It is a mandatory parameter when mapping flavor
+to project, and it have to be set to `false` in that case. Non public 
+flavor can't be mapped.  However there is possibility to create flavor which 
 is private and not mapped to any project. Only 'true' and 'false' are 
 allowed here.
 
 `project` list of project to which flavor should be mapped. In other 
 words: this flavor will be visible and usable only in said project. It is
- a dict, withpossible one element.
+a dict, with possible one element.
 
 Dependencies
 ------------
@@ -88,7 +89,7 @@ The following playbook will allow uasge of `flavor-1` only in project `projectA`
             auth_url: <keystone auth URL>
           os_flavors:
             - name: flavor-1
-              state: private
+              is_public: false
               project: "projectA"
 
 Author Information

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -29,4 +29,4 @@
     project: "{{ item.1 | default(omit) }}"
   loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}) }}"
   when: not item.0.is_public | bool
-
+  

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -29,3 +29,4 @@
     project: "{{ item.1 | default(omit) }}"
   loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}) }}"
   when: not item.0.is_public | bool
+

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -28,3 +28,4 @@
     state: "{{ item.0.state | default('present') }}"
     project: "{{ item.1 | default(omit) }}"
   loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}) }}"
+  when: not item.0.is_public | bool

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -12,7 +12,7 @@
     ephemeral: "{{ item.ephemeral | default(omit) }}"
     swap: "{{ item.swap | default(omit) }}"
     rxtx_factor: "{{ item.rxtx_factor | default(omit) }}"
-    is_public: "{{ item.is_public | default(omit) }}"
+    is_public: "{{ item.is_public | default('true') }}"
     flavorid: "{{ item.flavorid | default(omit) }}"
     extra_specs: "{{ item.extra_specs | default(omit) }}"
     state: "{{ item.state | default('present') }}"

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -28,4 +28,3 @@
     state: "{{ item.0.state | default('present') }}"
     project: "{{ item.1| default(omit) }}"
   loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}) }}"
-

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -29,4 +29,3 @@
     project: "{{ item.1 | default(omit) }}"
   loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}) }}"
   when: not item.0.is_public | bool
-  

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -28,3 +28,4 @@
     state: "{{ item.0.state | default('present') }}"
     project: "{{ item.1| default(omit) }}"
   loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}) }}"
+

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -17,3 +17,14 @@
     extra_specs: "{{ item.extra_specs | default(omit) }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ os_flavors }}"
+
+- name: Map nova flavors to projects
+  openstack.cloud.compute_flavor_access:
+    auth_type: "{{ os_flavors_auth_type }}"
+    auth: "{{ os_flavors_auth }}"
+    cacert: "{{ os_flavors_cacert | default(omit) }}"
+    interface: "{{ os_flavors_interface | default(omit, true) }}"
+    name: "{{ item.0.name }}"
+    state: "{{ item.0.state | default('present') }}"
+    project: "{{ item.1| default(omit) }}"
+  loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}) }}"

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -26,5 +26,5 @@
     interface: "{{ os_flavors_interface | default(omit, true) }}"
     name: "{{ item.0.name }}"
     state: "{{ item.0.state | default('present') }}"
-    project: "{{ item.1| default(omit) }}"
+    project: "{{ item.1 | default(omit) }}"
   loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}) }}"


### PR DESCRIPTION
This will add ability to map flavours to projects in Openstack.
It uses capabilities provided by module: https://github.com/openstack/ansible-collections-openstack/blob/master/plugins/modules/compute_flavor_access.py
