### PR TITLE
Fix mapping flavors to a single project

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: stackhpc
 name: openstack
-version: 0.5.0
+version: 0.5.1
 readme: README.md
 authors:
   - StackHPC Ltd

--- a/roles/os_flavors/tasks/flavors.yml
+++ b/roles/os_flavors/tasks/flavors.yml
@@ -27,5 +27,5 @@
     name: "{{ item.0.name }}"
     state: "{{ item.0.state | default('present') }}"
     project: "{{ item.1 | default(omit) }}"
-  loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}) }}"
+  loop: "{{ lookup('subelements', os_flavors, 'project', {'skip_missing': True}, wantlist=True) }}"
   when: not item.0.is_public | bool


### PR DESCRIPTION
Fixes an issue where the flavor mapping loop failed when only a single project was passed in.