### PR TITLE
subnetpool: Add subnetpool option to os_network

### DIFF
--- a/roles/os_networks/README.md
+++ b/roles/os_networks/README.md
@@ -70,8 +70,9 @@ dict containing the following items:
    - `ip_version`: Optional IP version for the subnet.
    - `ipv6_address_mode`: Optional IPv6 address mode for the subnet.
    - `ipv6_ra_mode`: Optional IPv6 router advertisement mode for the subnet.
-   - `use_default_subnetpool`: Optional boolean, whether to use the default
-     subnet pool for the IP version.
+   - `use_default_subnetpool`: **deprecated** Optional boolean, whether to use
+     the default subnet pool for the IP version.
+   - `subnetpool`: Optional subnetpool to use for the subnet.
    - `project`: Optionally create this subnet for a project other than the
      authenticating project.
    - `state`: Optional state of the subnet, default is `present`.

--- a/roles/os_networks/tasks/networks.yml
+++ b/roles/os_networks/tasks/networks.yml
@@ -56,6 +56,7 @@
     ipv6_address_mode: "{{ item.1.ipv6_address_mode | default(omit) }}"
     ipv6_ra_mode: "{{ item.1.ipv6_ra_mode | default(omit) }}"
     use_default_subnetpool: "{{ item.1.use_default_subnetpool | default(omit) }}"
+    subnetpool: "{{ item.1.subnetpool | default(omit) }}"
     project: "{{ item.1.project | default(omit) }}"
     state: "{{ item.1.state | default(omit) }}"
   with_subelements:


### PR DESCRIPTION
Deprecate use_default_subnetpool because it's only allowed during subnet creation and a subnet created with that field is non-updatable.

See [1].

[1]: https://github.com/openstack/ansible-collections-openstack/blob/f584c54dfd03e81c1e9c30e2d22f19d2d17a4353/plugins/modules/subnet.py#L348