### PR TITLE
Support allocation_pools parameter on subnets

### DIFF
--- a/roles/os_networks/tasks/networks.yml
+++ b/roles/os_networks/tasks/networks.yml
@@ -51,6 +51,7 @@
          default(item.1.gateway_ip | default | ternary(omit, True)) }}
     allocation_pool_start: "{{ item.1.allocation_pool_start | default(omit) }}"
     allocation_pool_end: "{{ item.1.allocation_pool_end | default(omit) }}"
+    allocation_pools: "{{ item.1.allocation_pools | default(omit) }}"
     host_routes: "{{ item.1.host_routes | default(omit) }}"
     ip_version: "{{ item.1.ip_version | default(omit) }}"
     ipv6_address_mode: "{{ item.1.ipv6_address_mode | default(omit) }}"


### PR DESCRIPTION
This allows you to define multiple allocation pools, which is useful if you have non-contiguous blocks of IP addresses.