### PR TITLE
Adds os_virtualenv_python

### DIFF
--- a/roles/os_openstackclient/defaults/main.yml
+++ b/roles/os_openstackclient/defaults/main.yml
@@ -3,6 +3,10 @@
 os_openstackclient_venv:
 # Whether to install package dependencies.
 os_openstackclient_install_package_dependencies: true
+# Value to use for the pip module's `virtualenv_command` argument when creating the virtualenv
+os_openstackclient_virtualenv_command: "{{ os_openstackclient_virtualenv_python ~ ' -m venv' if os_openstackclient_venv else omit }}"
+# Python interpreter to use in virtualenv command; `os_virtualenv_python` can be used to set this collection wide.
+os_openstackclient_virtualenv_python: "{{ os_virtualenv_python | default('python3.' ~ ansible_facts.python.version.minor) }}"
 
 # State of the openstackclient package.
 os_openstackclient_state: present

--- a/roles/os_openstackclient/tasks/main.yml
+++ b/roles/os_openstackclient/tasks/main.yml
@@ -14,6 +14,14 @@
   become: "{{ ansible_facts.system != 'Darwin' }}"
   when: os_openstackclient_install_package_dependencies | bool
 
+- name: Remove virtualenv if python version is stale
+  ansible.builtin.file:
+    path: "{{ os_openstackclient_venv }}"
+    state: absent
+  when:
+    - os_openstackclient_venv is not none
+    - (os_openstackclient_venv ~ '/bin/python') | realpath != os_openstackclient_virtualenv_python | realpath
+
 - name: Ensure the virtualenv directory exists
   when: os_openstackclient_venv is not none
   block:
@@ -40,7 +48,7 @@
     name: "{{ item.name }}"
     state: latest
     virtualenv: "{{ os_openstackclient_venv or omit }}"
-    virtualenv_command: "{{ 'python3.' ~ ansible_facts.python.version.minor ~ ' -m venv' if os_openstackclient_venv else omit }}"
+    virtualenv_command: "{{ os_openstackclient_virtualenv_command }}"
   with_items:
     - { name: pip }
     - { name: setuptools }

--- a/roles/os_openstacksdk/defaults/main.yml
+++ b/roles/os_openstacksdk/defaults/main.yml
@@ -2,7 +2,9 @@
 # Path to a directory in which to create a virtualenv.
 os_openstacksdk_venv:
 # Value to use for the pip module's `virtualenv_command` argument when creating the virtualenv
-os_openstacksdk_virtualenv_command: "{{ 'python3.' ~ ansible_facts.python.version.minor ~ ' -m venv' if os_openstacksdk_venv else omit }}"
+os_openstacksdk_virtualenv_command: "{{ os_openstacksdk_virtualenv_python ~ ' -m venv' if os_openstacksdk_venv else omit }}"
+# Python interpreter to use in virtualenv command; `os_virtualenv_python` can be used to set this collection wide.
+os_openstacksdk_virtualenv_python: "{{ os_virtualenv_python | default('python3.' ~ ansible_facts.python.version.minor) }}"
 
 # Whether to install package dependencies.
 os_openstacksdk_install_package_dependencies: true

--- a/roles/os_openstacksdk/tasks/main.yml
+++ b/roles/os_openstacksdk/tasks/main.yml
@@ -20,6 +20,14 @@
   become: "{{ ansible_facts.system != 'Darwin' }}"
   when: os_openstacksdk_install_package_dependencies | bool
 
+- name: Remove virtualenv if python version is stale
+  ansible.builtin.file:
+    path: "{{ os_openstacksdk_venv }}"
+    state: absent
+  when:
+    - os_openstacksdk_venv is not none
+    - (os_openstacksdk_venv ~ '/bin/python') | realpath != os_openstacksdk_virtualenv_python | realpath
+
 - name: Ensure the virtualenv directory exists
   when: os_openstacksdk_venv is not none
   block:


### PR DESCRIPTION
  This sets the collection wide python interpretter. This can also be set
  on a per role basis with:

  - os_openstackclient_virtualenv_python
  - os_openstacksdk_virtualenv_python
    
If python version changes, it will create the virtualenv with the new interpreter.

  Also adds:

  - os_openstackclient_virtualenv_command

    Depending on the version of upper constraints, you may need to use a
    newer python interpreter.