### PR TITLE
Adds create_user option to optionally skip user creation

### DIFF
--- a/roles/os_projects/README.md
+++ b/roles/os_projects/README.md
@@ -50,6 +50,9 @@ Each item should be a dict containing the following items:
   - `domain_roles`: Optional list of roles to assign to the user in the user
     domain.
   - `openrc_file`: Path to an environment file to create.
+  - `create_user`: Boolean to indicate whether or not to create the user.  Can
+    be useful if the user already exists e.g the user is defined in LDAP.
+    (optional)
 - `keypairs`: Optional list of SSH key pairs to register with Nova. Each key
   pair should be a dict containing the following items:
   - `name`: The name of the keypair.

--- a/roles/os_projects/tasks/users.yml
+++ b/roles/os_projects/tasks/users.yml
@@ -16,6 +16,7 @@
     enabled: true
     wait: true
   with_items: "{{ project.users }}"
+  when: item.create_user | default(true) | bool
   environment: "{{ os_projects_environment }}"
   vars:
     domain_is_id: "{{ project.user_domain in os_projects_domain_to_id.values() }}"


### PR DESCRIPTION
Can be useful for LDAP users, where you do no wish to create them, but you do want to assign roles.