### PR TITLE
Adding user_domain and project_domain options and suitable fallbacks/omission

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,7 +12,7 @@ tags:
   - cloud
   - openstack
 dependencies:
-  "openstack.cloud": ">=2.1.0"
+  "openstack.cloud": ">=2.5.0"
   "community.general": ">=8.2.0"
 repository: https://github.com/stackhpc/ansible-collection-openstack
 documentation: https://github.com/stackhpc/ansible-collection-openstack/blob/main/README.md

--- a/roles/os_projects/tasks/users.yml
+++ b/roles/os_projects/tasks/users.yml
@@ -35,6 +35,8 @@
     user: "{{ item.0.name }}"
     project: "{{ project.name }}"
     role: "{{ item.1 }}"
+    user_domain: "{{ project.user_domain | default(omit, true) }}"
+    project_domain: "{{ project.project_domain | default(omit, true) }}"
     state: present
   with_subelements:
     - "{{ project.users }}"


### PR DESCRIPTION
Adding user_domain and project_domain options and suitable fallbacks/omission.

This requires openstack.cloud 2.5.0 specifically commit 437438e33c

See https://opendev.org/openstack/ansible-collections-openstack/commit/437438e33c836d50c1f6e3ef22a88226fdac239d for further usage