### PR TITLE
os_projects: skip default_project for cross-domain users

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: stackhpc
 name: openstack
-version: 0.10.0
+version: 0.10.1
 readme: README.md
 authors:
   - StackHPC Ltd

--- a/roles/os_projects/README.md
+++ b/roles/os_projects/README.md
@@ -62,6 +62,11 @@ Each item should be a dict containing the following items:
   - `public_key_file`: Path to the SSH public key on the control host.
 - `quotas`: Optional dict mapping quota names to their values.
 
+Note: when `user_domain` and `project_domain` differ, the role omits
+`default_project` during user creation to avoid false "No Project found"
+errors from `openstack.cloud.identity_user`. Cross-domain role assignments are
+still applied.
+
 `os_projects_upper_constraints_file` is a path to an upper constraints file which
 is passed through to the role dependencies.
 

--- a/roles/os_projects/tasks/users.yml
+++ b/roles/os_projects/tasks/users.yml
@@ -11,8 +11,11 @@
     description: "{{ item.description | default(omit) }}"
     email: "{{ item.email | default(omit) }}"
     password: "{{ item.password | default(omit) }}"
-    default_project: "{{ project.name }}"
-    domain: "{{ domain_is_id | ternary(project.user_domain, os_projects_domain_to_id[project.user_domain]) }}"
+    # NOTE(bbezak): identity_user looks up default_project in the user domain
+    # ('domain'). Omit default_project for cross-domain users to avoid false
+    # "No Project found" errors.
+    default_project: "{{ (user_domain_id == project_domain_id) | ternary(project.name, omit) }}"
+    domain: "{{ user_domain_id }}"
     state: present
     enabled: true
     wait: true
@@ -20,7 +23,8 @@
   when: item.create_user | default(true) | bool
   environment: "{{ os_projects_environment }}"
   vars:
-    domain_is_id: "{{ project.user_domain in os_projects_domain_to_id.values() }}"
+    user_domain_id: "{{ (project.user_domain in os_projects_domain_to_id.values()) | ternary(project.user_domain, os_projects_domain_to_id[project.user_domain]) }}"
+    project_domain_id: "{{ (project.project_domain in os_projects_domain_to_id.values()) | ternary(project.project_domain, os_projects_domain_to_id[project.project_domain]) }}"
   loop_control:
     label: "{{ project.name }}: {{ item.name }}"
 


### PR DESCRIPTION
identity_user resolves default_project in the user domain.
When project_domain != user_domain this can fail with "No Project found".
Only set default_project when both domains match; role assignments still run.